### PR TITLE
Add Sepolia deployment

### DIFF
--- a/networks.json
+++ b/networks.json
@@ -3,6 +3,10 @@
     "1": {
       "address": "0x08cd77feb3fb28cc1606a91e0ea2f5e3eaba1a9a",
       "transactionHash": "0xef142de4c3677da85a4d9d02b5c78e5ebf09af01df0114e1b4a681311ee37a0f"
+    },
+    "11155111": {
+      "address": "0x2C90BFfCd949d40A0832864234Bfa624c08bAD00",
+      "transactionHash": "0x34dfbccc5e8e722e6347cac2b781b542c72980cdd6af4f88579f60cfc8197c5e"
     }
   }
 }


### PR DESCRIPTION
Adds a testing contract for Sepolia whose owner `0xA03be496e67Ec29bC62F01a428683D7F9c204930` is managed by the team. This contract can be used by anyone for testing purposes.

Thanks @cowanator for the suggestion and contribution in #3.

### How to test

Etherscan contract verification and deployment parameters.